### PR TITLE
Add missing stuff

### DIFF
--- a/addon/src/main/scala/vaadin/scala/AbstractField.scala
+++ b/addon/src/main/scala/vaadin/scala/AbstractField.scala
@@ -31,8 +31,6 @@ trait Field[T] extends Component with BufferedValidatable with Property[T] with 
   def requiredError: Option[String] = Option(p.getRequiredError)
   def requiredError_=(requiredError: String): Unit = p.setRequiredError(requiredError)
   def requiredError_=(requiredError: Option[String]): Unit = p.setRequiredError(requiredError.orNull)
-
-  def valid: Boolean = p.isValid
 }
 
 abstract class AbstractField[T](override val p: com.vaadin.ui.AbstractField[T] with AbstractFieldMixin[T])

--- a/addon/src/main/scala/vaadin/scala/AbstractField.scala
+++ b/addon/src/main/scala/vaadin/scala/AbstractField.scala
@@ -31,6 +31,8 @@ trait Field[T] extends Component with BufferedValidatable with Property[T] with 
   def requiredError: Option[String] = Option(p.getRequiredError)
   def requiredError_=(requiredError: String): Unit = p.setRequiredError(requiredError)
   def requiredError_=(requiredError: Option[String]): Unit = p.setRequiredError(requiredError.orNull)
+
+  def valid: Boolean = p.isValid
 }
 
 abstract class AbstractField[T](override val p: com.vaadin.ui.AbstractField[T] with AbstractFieldMixin[T])

--- a/addon/src/main/scala/vaadin/scala/AbstractSelect.scala
+++ b/addon/src/main/scala/vaadin/scala/AbstractSelect.scala
@@ -49,6 +49,8 @@ abstract class AbstractSelect(override val p: com.vaadin.ui.AbstractSelect with 
   def itemCaptionPropertyId_=(itemCaptionPropertyId: Option[Any]) = p.setItemCaptionPropertyId(itemCaptionPropertyId.orNull)
   def itemCaptionPropertyId_=(itemCaptionPropertyId: Any) = p.setItemCaptionPropertyId(itemCaptionPropertyId)
 
+  def getItemCaption(item: Any): String = p.getItemCaption(item)
+
   def setItemCaption(item: Any, caption: String) = p.setItemCaption(item, caption)
 
   def itemIconPropertyId: Option[Any] = Option(p.getItemIconPropertyId)

--- a/addon/src/main/scala/vaadin/scala/AbstractSelect.scala
+++ b/addon/src/main/scala/vaadin/scala/AbstractSelect.scala
@@ -49,6 +49,8 @@ abstract class AbstractSelect(override val p: com.vaadin.ui.AbstractSelect with 
   def itemCaptionPropertyId_=(itemCaptionPropertyId: Option[Any]) = p.setItemCaptionPropertyId(itemCaptionPropertyId.orNull)
   def itemCaptionPropertyId_=(itemCaptionPropertyId: Any) = p.setItemCaptionPropertyId(itemCaptionPropertyId)
 
+  def setItemCaption(item: Any, caption: String) = p.setItemCaption(item, caption)
+
   def itemIconPropertyId: Option[Any] = Option(p.getItemIconPropertyId)
   def itemIconPropertyId_=(itemIconPropertyId: Option[Any]) = p.setItemIconPropertyId(itemIconPropertyId.orNull)
   def itemIconPropertyId_=(itemIconPropertyId: Any) = p.setItemIconPropertyId(itemIconPropertyId)

--- a/addon/src/main/scala/vaadin/scala/Validation.scala
+++ b/addon/src/main/scala/vaadin/scala/Validation.scala
@@ -66,6 +66,8 @@ trait Validatable extends Wrapper {
   lazy val validators: Validators = new Validators(p)
 
   def validate: Validation = Validation.wrapToValidation(p.validate)
+
+  def valid: Boolean = p.isValid
 }
 
 class ValidatorDelegator extends com.vaadin.data.Validator with ValidatorMixin {


### PR DESCRIPTION
Added assorted bits that I'd found myself missing:

AbstractField.valid

AbstractSelect.setItemCaption: Don't know if this should be AbstractSelect.itemCaption, but it felt like I should prepend "set" because it isn't a single variable. Maybe it'd be better modeled as a Map[Any, String] but I don't know enough about Scaladin internals to pull that off.

Select: I was surprised that there was a NativeSelect component but not a plain Select.
