### PR TITLE
BeanItemContainer: addBean, getItem, getItemOption

### DIFF
--- a/addon/src/main/scala/vaadin/scala/BeanItemContainer.scala
+++ b/addon/src/main/scala/vaadin/scala/BeanItemContainer.scala
@@ -21,9 +21,15 @@ class BeanItemContainer[BT](override val p: com.vaadin.data.util.BeanItemContain
     this(new com.vaadin.data.util.BeanItemContainer[BT](m.runtimeClass.asInstanceOf[Class[BT]], beans.asJavaCollection) with BeanItemContainerMixin)
   }
 
-  def addBean(bean: BT): BeanItem[BT] = new BeanItem[BT](bean)
+  def addBean(bean: BT): BeanItem[BT] = new BeanItem[BT](p.addBean(bean))
 
-  def wrapItem(unwrapped: com.vaadin.data.Item): Item = {
+  override def getItem(itemId: Any): BeanItem[BT] =
+    super.getItem(itemId).asInstanceOf[BeanItem[BT]]
+
+  override def getItemOption(itemId: Any): Option[BeanItem[BT]] =
+    super.getItemOption(itemId).map(_.asInstanceOf[BeanItem[BT]])
+
+  def wrapItem(unwrapped: com.vaadin.data.Item): BeanItem[BT] = {
     // must create BeanItem with the constructor that takes a Vaadin BeanItem not a bean.
     new BeanItem[BT](unwrapped.asInstanceOf[com.vaadin.data.util.BeanItem[BT]])
   }

--- a/addon/src/test/scala/vaadin/scala/tests/BeanItemContainerTests.scala
+++ b/addon/src/test/scala/vaadin/scala/tests/BeanItemContainerTests.scala
@@ -14,6 +14,8 @@ class BeanItemContainerTests extends FunSuite
     with ContainerTestItemIdsAndContainsId
     with ContainerTestIndexed {
 
+  case class Foo(@BeanProperty var bar: String, @BeanProperty var baz: Int)
+
   var container: BeanItemContainer[Any] = _
 
   before {
@@ -34,10 +36,28 @@ class BeanItemContainerTests extends FunSuite
   }
 
   test("propertyIds should return correct field names") {
-    case class Foo(@BeanProperty var bar: String, @BeanProperty var baz: Int)
-
     val bean = new Foo("test", 123)
     val container = new BeanItemContainer(bean :: Nil)
     assert(container.getItem(bean).propertyIds.toSeq === List("bar", "baz").toSeq)
+  }
+
+  test("getting item from container should return a bean item with correct bean") {
+    val b1 = Foo("first", 1)
+    val b2 = Foo("second", 2)
+
+    val container = new BeanItemContainer[Foo](b1 :: b2 :: Nil)
+
+    assert(container.getItem(b1).bean === b1)
+    assert(container.getItem(b2).bean === b2)
+  }
+
+  test("adding a bean to container should return a bean item") {
+    val bean = Foo("bar", 99)
+
+    val container = new BeanItemContainer[Foo]()
+    val beanItem = container.addBean(bean)
+
+    assert(beanItem.bean === bean)
+    assert(container.getItem(bean).bean === bean)
   }
 }


### PR DESCRIPTION
Adding beans now adds the beans to the container.

Items received from Container trait's getItem and getItemOption are of type BeanItem because of wrapItem. Exposing BeanItem to the user of BeanItemContainer makes the actual bean available when getting items. The original Vaadin BeanItemContainer also does this.
