### PR TITLE
Fixed creation of FieldGroup. Now the 'item' property is bound to the pa...

### DIFF
--- a/addon/src/main/scala/vaadin/scala/FieldGroup.scala
+++ b/addon/src/main/scala/vaadin/scala/FieldGroup.scala
@@ -29,7 +29,9 @@ object FieldGroup {
   case class propertyId(value: String) extends StaticAnnotation
 
   def apply(item: Item): FieldGroup = {
-    new FieldGroup(new VaadinFieldGroup(item.p) with FieldGroupMixin)
+    val fieldGroup = new FieldGroup(new VaadinFieldGroup() with FieldGroupMixin)
+    fieldGroup.item_=(item)
+    fieldGroup
   }
 }
 


### PR DESCRIPTION
...rent one. 
Before this fix there was a defect with an empty 'item' property of a newly created FieldGroup using an item as a parameter, like as follows:

case class Employee(name: String)
val fieldGroup = FieldGroup(ScaladinItem(Employee("some name")))

When getting an item from a fieldGroup, None was always returned.
val i = fieldGroup.item // was always None, because 'protected var itemWrapper' was not initialized.
