### PR TITLE
Fix #72 and fix #74

### DIFF
--- a/addon/src/main/scala/vaadin/scala/FieldGroup.scala
+++ b/addon/src/main/scala/vaadin/scala/FieldGroup.scala
@@ -22,7 +22,7 @@ object FieldGroup {
   case class PostCommitEvent(fieldBinder: FieldGroup)
 
   case class CommitSuccess()
-  case class CommitFailed(error: String)
+  case class CommitFailed(exception: VaadinCommitException)
   type CommitResult = Either[CommitFailed, CommitSuccess]
 
   case class propertyId(value: String) extends StaticAnnotation
@@ -101,7 +101,7 @@ class FieldGroup(override val p: VaadinFieldGroup with FieldGroupMixin = new Vaa
   def unboundPropertyIds: Iterable[Any] = p.getUnboundPropertyIds.asScala
 
   def commit(): FieldGroup.CommitResult = catching(classOf[VaadinCommitException]) either (p.commit) fold (
-    exception => Left(FieldGroup.CommitFailed(exception.getMessage)),
+    exception => Left(FieldGroup.CommitFailed(exception.asInstanceOf[VaadinCommitException])),
     nothing => Right(FieldGroup.CommitSuccess()))
 
   def discard() { p.discard() }

--- a/addon/src/main/scala/vaadin/scala/converter/DefaultConverterFactory.scala
+++ b/addon/src/main/scala/vaadin/scala/converter/DefaultConverterFactory.scala
@@ -2,6 +2,8 @@ package vaadin.scala.converter
 
 import java.util.Date
 
+import vaadin.scala.Wrapper
+import vaadin.scala.converter.mixins.{ DelegatingConverterMixin, ConverterMixin }
 import vaadin.scala.server.Resource
 import com.vaadin.server.{ Resource => VaadinResource }
 
@@ -56,12 +58,16 @@ object DefaultConverterFactory extends ConverterFactory {
       Option(new StringToShortConverter)
     else if (classOf[Byte].isAssignableFrom(sourceType) || classOf[java.lang.Byte].isAssignableFrom(sourceType))
       Option(new StringToByteConverter)
-    else None
+    else
+      None
   }
 
   private[this] def createDateConverter(sourceType: Class[_]): Option[Converter[Date, _]] = {
     if (classOf[Long].isAssignableFrom(sourceType) || classOf[java.lang.Long].isAssignableFrom(sourceType))
       Option(new DateToLongConverter)
-    else None
+    else if (classOf[java.sql.Date].isAssignableFrom(sourceType))
+      Option(new DateToSqlDateConverter)
+    else
+      None
   }
 }

--- a/addon/src/main/scala/vaadin/scala/converter/converters.scala
+++ b/addon/src/main/scala/vaadin/scala/converter/converters.scala
@@ -1,6 +1,11 @@
 package vaadin.scala.converter
 
-import vaadin.scala.converter.mixins.ConverterMixin
+import java.util.Locale
+
+import vaadin.scala.Wrapper
+import vaadin.scala.converter.mixins.{ DelegatingConverterMixin, ConverterMixin }
+
+import scala.reflect.ClassTag
 
 class DateToLongConverter extends DeletagePeerConverter[java.util.Date, java.lang.Long](
   new com.vaadin.data.util.converter.DateToLongConverter with ConverterMixin[java.util.Date, java.lang.Long])
@@ -34,3 +39,6 @@ class StringToShortConverter extends DeletagePeerConverter[java.lang.String, jav
 
 class StringToByteConverter extends DeletagePeerConverter[java.lang.String, java.lang.Byte](
   new com.vaadin.data.util.converter.StringToByteConverter with ConverterMixin[java.lang.String, java.lang.Byte])
+
+class DateToSqlDateConverter extends DeletagePeerConverter[java.util.Date, java.sql.Date](
+  new com.vaadin.data.util.converter.DateToSqlDateConverter with ConverterMixin[java.util.Date, java.sql.Date])

--- a/addon/src/main/scala/vaadin/scala/internal/handlers.scala
+++ b/addon/src/main/scala/vaadin/scala/internal/handlers.scala
@@ -8,7 +8,7 @@ import vaadin.scala.FieldGroup
 
 class PreCommitHandler(val action: PreCommitEvent => CommitResult) extends com.vaadin.data.fieldgroup.FieldGroup.CommitHandler with Handler[PreCommitEvent, CommitResult] {
   def preCommit(e: com.vaadin.data.fieldgroup.FieldGroup.CommitEvent): Unit = action(PreCommitEvent(wrapperFor[FieldGroup](e.getFieldBinder()).get)) fold (
-    failure => throw new com.vaadin.data.fieldgroup.FieldGroup.CommitException(failure.error),
+    failure => throw new com.vaadin.data.fieldgroup.FieldGroup.CommitException(failure.exception),
     success => ())
   def postCommit(e: com.vaadin.data.fieldgroup.FieldGroup.CommitEvent): Unit = {}
 }
@@ -16,6 +16,6 @@ class PreCommitHandler(val action: PreCommitEvent => CommitResult) extends com.v
 class PostCommitHandler(val action: PostCommitEvent => CommitResult) extends com.vaadin.data.fieldgroup.FieldGroup.CommitHandler with Handler[PostCommitEvent, CommitResult] {
   def preCommit(e: com.vaadin.data.fieldgroup.FieldGroup.CommitEvent): Unit = {}
   def postCommit(e: com.vaadin.data.fieldgroup.FieldGroup.CommitEvent): Unit = action(PostCommitEvent(wrapperFor[FieldGroup](e.getFieldBinder()).get)) fold (
-    failure => throw new com.vaadin.data.fieldgroup.FieldGroup.CommitException(failure.error),
+    failure => throw new com.vaadin.data.fieldgroup.FieldGroup.CommitException(failure.exception),
     success => ())
 }

--- a/addon/src/test/scala/vaadin/scala/tests/ConverterTests.scala
+++ b/addon/src/test/scala/vaadin/scala/tests/ConverterTests.scala
@@ -1,7 +1,7 @@
 package vaadin.scala.tests
 
 import vaadin.scala._
-import converter.{ DateToLongConverter, Converter }
+import vaadin.scala.converter.{DateToSqlDateConverter, DefaultConverterFactory, DateToLongConverter, Converter}
 import org.scalatest.FunSuite
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -55,4 +55,11 @@ class ConverterTests extends FunSuite {
     assert(converter.convertToPresentation(Some(1358627734477L), classOf[java.util.Date], locale) === Some(new Date(1358627734477L)))
   }
 
+  test("DateToSQLConverter") {
+    val converter = DefaultConverterFactory.createConverter[java.util.Date, java.sql.Date]
+    assert(converter.isDefined)
+    assert(converter.get.isInstanceOf[DateToSqlDateConverter])
+    assert(converter.get.presentationType === classOf[java.util.Date])
+    assert(converter.get.modelType === classOf[java.sql.Date])
+  }
 }


### PR DESCRIPTION
Fix:
#72: On FieldGroup.commit() fail, provide access to underlying Exception
#74: Integrate Vaadin's automatic DateField<->java.sql.Date Converter
